### PR TITLE
Fix "bad minute" and "errors in crontab file, can't install."

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,3 +1,3 @@
-#run python script every minutes
+# START CRON JOB
 * * * * * python /app/hello.py > /proc/1/fd/1 2>/proc/1/fd/2
-
+# END CRON JOB


### PR DESCRIPTION
Cron tab requires at least the first and last lines of the file not to be actual cron instructions. You can put comments instead - such as those below in a file